### PR TITLE
Adding support for webpack requires inside templates

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,12 @@ module.exports = function(content) {
     if (opt.raw) {
       callback(null, content);
     } else {
-      callback(null, "module.exports = " + JSON.stringify(content));
+      content = "module.exports = " + JSON.stringify(content)
+      content = content.replace(
+        /__WEBPACK_TEMPLATE_HTML_LOADER__\(([^\)]+)\)/g,
+        '" + require("$1") + "'
+      )
+      callback(null, content);
     }
   }
 
@@ -28,6 +33,9 @@ module.exports = function(content) {
 
   // for relative includes
   opt.filename = this.resourcePath;
+  opt.require = function(path) {
+    return "__WEBPACK_TEMPLATE_HTML_LOADER__("+path+")"
+  }
 
   cons[opt.engine].render(content, opt, function(err, html) {
     if(err) {


### PR DESCRIPTION
Makes the require function accessible inside functions.

Example with jade:

```jade
doctype html
html(lang="en")
  head
    link(rel="icon", href=require("file!favicon.png"))
```

The require function can be used with the url-loader or file-loader to generate cache busting URLs as well as inlined base64 encoded images.

Related: https://github.com/jtangelder/template-html-loader/issues/4
